### PR TITLE
Select saved destination from list

### DIFF
--- a/TwoWheels/ViewModels/ExploreViewModel.swift
+++ b/TwoWheels/ViewModels/ExploreViewModel.swift
@@ -128,6 +128,11 @@ class ExploreViewModel {
         isInfoSheetPresented = false
     }
     
+    func selectDestinationFromList(_ destination: Destination) {
+        selectedDestination = destination
+        selectedTab = .map
+    }
+    
     private func search(_ request: MKLocalSearch.Request) async {
         do {
             searchResults = try await searchService.search(with: request).compactMap {

--- a/TwoWheels/Views/Explore/DestinationsListView.swift
+++ b/TwoWheels/Views/Explore/DestinationsListView.swift
@@ -16,14 +16,19 @@ struct DestinationsListView: View {
         NavigationStack {
             if !viewModel.destinations.isEmpty {
                 List(viewModel.destinations, id: \.self) { destination in
-                    HStack {
-                        Image(systemName: "mappin.circle")
-                            .imageScale(.large)
-                        
-                        VStack(alignment: .leading) {
-                            Text(destination.title)
+                    Button {
+                        viewModel.selectDestinationFromList(destination)
+                    } label: {
+                        HStack {
+                            Image(systemName: "mappin.circle")
+                                .imageScale(.large)
+                            
+                            VStack(alignment: .leading) {
+                                Text(destination.title)
+                            }
                         }
                     }
+                    .buttonStyle(PlainButtonStyle())
                     .swipeActions(edge: .trailing) {
                         Button(role: .destructive) {
                             viewModel.deleteDestination(destination)

--- a/TwoWheelsTests/ExploreViewModelTests.swift
+++ b/TwoWheelsTests/ExploreViewModelTests.swift
@@ -332,6 +332,14 @@ struct ExploreViewModelTests {
         #expect(sut.tappedLocations.isEmpty)
         #expect(!sut.isInfoSheetPresented)
     }
+    
+    @Test
+    func selectDestinationFromList_shouldChangeTabSelectionAndSetSelectedDestination() {
+        sut.selectDestinationFromList(laneStadiumDestination)
+        
+        #expect(sut.selectedTab == .map)
+        #expect(sut.selectedDestination == laneStadiumDestination)
+    }
 }
 
 extension MKCoordinateRegion: @retroactive Equatable {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- You can now tap on a destination row to select it and automatically switch to the map view.
- **Tests**
	- Added a test to ensure selecting a destination updates the selected tab and destination as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->